### PR TITLE
.github/workflows/docker.yml: Restrict permissions for GITHUB_TOKEN

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,12 +32,12 @@ jobs:
         run: |
           if [[ -z "${GITHUB_BASE_REF}" ]]; then
             # On master/stable branches.
-            branch=${GITHUB_REF#refs/heads/}
+            tag=${GITHUB_REF#refs/heads/}
           else
             # On pull request branches.
-            branch=pr-$(git describe --always --abbrev=7)
+            tag=pr-$(git describe --always --abbrev=7)
           fi
-          tag=${branch//\//-}
+          tag=${tag//\//-}
           echo "tag=${tag}" >> $GITHUB_OUTPUT
           echo "created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
As a good security practice, we should grant the `GITHUB_TOKEN` [the least required access](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token).