### PR TITLE
Style success and error messages

### DIFF
--- a/faucet-frontend/src/main.js
+++ b/faucet-frontend/src/main.js
@@ -3,10 +3,13 @@
 function showResponseStatus(error, status, requestBody) {
   document.querySelector('#request-form').style.display = 'none';
   document.querySelector('#response-display').style.display = 'block';
+  document.querySelector('#response-display-text').style.textAlign = 'center';
   if (error) {
     document.querySelector('#response-display-text').textContent = error;
+    document.querySelector('#response-display-text').style.color = '#d1001f';
   } else {
     document.querySelector('#response-display-text').textContent = status;
+    document.querySelector('#response-display-text').style.color = '#4BB543';
     if (requestBody.get('paratime') === 'emerald') {}
     if (requestBody.get('paratime') === 'sapphire') {}
   }


### PR DESCRIPTION
Fixes https://github.com/oasisprotocol/testnet-faucet/issues/23

Added color and alignment of response display text.

Before:
<img width="713" alt="Screenshot 2025-01-06 at 13 57 29" src="https://github.com/user-attachments/assets/daf731a9-97e2-47ad-83c5-1497dcd4056f" />

After:
<img width="450" alt="Screenshot 2025-01-07 at 21 23 31" src="https://github.com/user-attachments/assets/8503be5b-a80e-4e7f-abb9-316d97b85904" />
