### PR TITLE
.github/workflows: Push Docker images only when merged to main

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -57,7 +57,7 @@ jobs:
           file: deploy/Dockerfile
           tags: ghcr.io/oasisprotocol/testnet-faucet:${{ steps.determine_tag.outputs.tag }}
           pull: true
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           provenance: false
           labels: |
             org.opencontainers.image.authors=${{ github.actor }}
@@ -68,6 +68,7 @@ jobs:
             org.opencontainers.image.revision=${{ github.sha }}
 
       - name: Prune old ghcr.io/oasisprotocol/testnet-faucet images
+        if: github.event_name != 'pull_request'
         uses: vlaurin/action-ghcr-prune@v0.6.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
GitHub intentionally blocks secrets and write tokens for fork PRs on `pull_request` events. With these changes, fork PRs still get a build (validates the Dockerfile compiles), but the push is skipped. Images are only pushed when a PR is merged and the push event fires on main.